### PR TITLE
[NO-TICKET]: Unblock Nightly Docs Sync

### DIFF
--- a/.github/workflows/nightly-docs-sync.yml
+++ b/.github/workflows/nightly-docs-sync.yml
@@ -22,9 +22,270 @@ env:
   VURVEY_URL: 'https://staging.vurvey.dev'
 
 jobs:
-  sync-documentation:
+  capture-screenshots:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout documentation repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Puppeteer browser
+        run: npx puppeteer browsers install chrome
+
+      - name: Capture screenshots
+        env:
+          VURVEY_EMAIL: ${{ secrets.VURVEY_EMAIL }}
+          VURVEY_PASSWORD: ${{ secrets.VURVEY_PASSWORD }}
+          VURVEY_URL: ${{ env.VURVEY_URL }}
+          VURVEY_WORKSPACE_ID: ${{ secrets.VURVEY_WORKSPACE_ID || '07e5edb5-e739-4a35-9f82-cc6cec7c0193' }}
+          HEADLESS: 'true'
+          CAPTURE_STRICT: 'false'
+        continue-on-error: true
+        run: |
+          echo "Capturing screenshots from staging environment..."
+          npm run update:screenshots
+
+      - name: Validate screenshot references and capture report
+        env:
+          DOCS_LINT_USE_CAPTURE_REPORT: 'true'
+        run: npm run lint:docs
+
+      - name: Upload screenshot files
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-screenshot-files
+          path: docs/public/screenshots/
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Upload capture artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-screenshot-capture-artifacts
+          path: qa-output/capture-screenshots/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  qa-deep:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - name: Checkout documentation repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout vurvey-web-manager (for route discovery)
+        uses: actions/checkout@v4
+        with:
+          repository: batterii/vurvey-web-manager
+          path: vurvey-web-manager
+          token: ${{ secrets.VURVEY_REPO_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Puppeteer browser
+        run: npx puppeteer browsers install chrome
+
+      - name: Run QA tests
+        env:
+          VURVEY_EMAIL: ${{ secrets.VURVEY_EMAIL }}
+          VURVEY_PASSWORD: ${{ secrets.VURVEY_PASSWORD }}
+          VURVEY_URL: ${{ env.VURVEY_URL }}
+          VURVEY_WORKSPACE_ID: ${{ secrets.VURVEY_WORKSPACE_ID || '07e5edb5-e739-4a35-9f82-cc6cec7c0193' }}
+          HEADLESS: 'true'
+          QA_DEEP: 'true'
+          QA_WEB_MANAGER_DIR: 'vurvey-web-manager'
+        run: |
+          echo "Running QA test suite..."
+          npm run test:qa -- --deep || echo "QA tests completed with some failures"
+        continue-on-error: true
+
+      - name: Upload QA artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-qa-deep-artifacts
+          path: |
+            qa-output/
+            qa-failure-screenshots/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  qa-web-manager-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+
+    steps:
+      - name: Checkout documentation repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout vurvey-web-manager
+        uses: actions/checkout@v4
+        with:
+          repository: batterii/vurvey-web-manager
+          path: vurvey-web-manager
+          token: ${{ secrets.VURVEY_REPO_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: |
+            package-lock.json
+            vurvey-web-manager/package-lock.json
+
+      - name: Run web-manager Playwright smoke tests
+        env:
+          VURVEY_EMAIL: ${{ secrets.VURVEY_EMAIL }}
+          VURVEY_PASSWORD: ${{ secrets.VURVEY_PASSWORD }}
+          VURVEY_URL: ${{ env.VURVEY_URL }}
+          QA_WEB_MANAGER_DIR: 'vurvey-web-manager'
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "Running web-manager Playwright smoke tests..."
+          bash scripts/run-web-manager-playwright-smoke.sh || echo "web-manager Playwright smoke tests completed with some failures"
+        continue-on-error: true
+
+      - name: Upload web-manager Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-web-manager-playwright-artifacts
+          path: |
+            vurvey-web-manager/test-results/
+            vurvey-web-manager/playwright-report/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  qa-mobile-viewport:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout documentation repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Puppeteer browser
+        run: npx puppeteer browsers install chrome
+
+      - name: Run mobile viewport QA
+        env:
+          VURVEY_EMAIL: ${{ secrets.VURVEY_EMAIL }}
+          VURVEY_PASSWORD: ${{ secrets.VURVEY_PASSWORD }}
+          VURVEY_URL: ${{ env.VURVEY_URL }}
+          VURVEY_WORKSPACE_ID: ${{ secrets.VURVEY_WORKSPACE_ID || '07e5edb5-e739-4a35-9f82-cc6cec7c0193' }}
+          HEADLESS: 'true'
+        run: |
+          echo "Running mobile viewport QA..."
+          npm run test:qa:mobile || echo "mobile viewport QA completed with some failures"
+        continue-on-error: true
+
+      - name: Upload mobile QA artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-mobile-qa-artifacts
+          path: qa-output/viewport-tests/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  qa-doc-claims:
+    name: qa-doc-claims (shard ${{ matrix.shard }}/20)
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]
+
+    steps:
+      - name: Checkout documentation repo
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium --with-deps
+
+      - name: Run doc-claim Playwright tests
+        env:
+          VURVEY_EMAIL: ${{ secrets.VURVEY_EMAIL }}
+          VURVEY_PASSWORD: ${{ secrets.VURVEY_PASSWORD }}
+          VURVEY_URL: ${{ env.VURVEY_URL }}
+          VURVEY_WORKSPACE_ID: ${{ secrets.VURVEY_WORKSPACE_ID || '07e5edb5-e739-4a35-9f82-cc6cec7c0193' }}
+          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
+        run: |
+          echo "Running doc-claim Playwright shard ${{ matrix.shard }}/20..."
+          npm run test:pw -- --shard=${{ matrix.shard }}/20 --retries=0 --max-failures=10
+        continue-on-error: true
+
+      - name: Upload doc-claim artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-doc-claims-${{ matrix.shard }}
+          path: |
+            playwright/playwright-report/
+            playwright/test-results/
+          retention-days: 7
+          if-no-files-found: ignore
+
+  sync-documentation:
+    runs-on: ubuntu-latest
+    needs: [capture-screenshots, qa-deep]
+    timeout-minutes: 45
     outputs:
       has_bug_reports: ${{ steps.check_bugs.outputs.has_bugs }}
       bug_reports: ${{ steps.check_bugs.outputs.bug_reports }}
@@ -58,107 +319,64 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
+          cache-dependency-path: package-lock.json
 
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Puppeteer browser
-        run: npx puppeteer browsers install chrome
-
-      - name: Capture screenshots
-        env:
-          VURVEY_EMAIL: ${{ secrets.VURVEY_EMAIL }}
-          VURVEY_PASSWORD: ${{ secrets.VURVEY_PASSWORD }}
-          VURVEY_URL: ${{ env.VURVEY_URL }}
-          VURVEY_WORKSPACE_ID: ${{ secrets.VURVEY_WORKSPACE_ID || '07e5edb5-e739-4a35-9f82-cc6cec7c0193' }}
-          HEADLESS: 'true'
-          CAPTURE_STRICT: 'false'
+      - name: Download screenshot files
+        uses: actions/download-artifact@v4
+        with:
+          name: nightly-screenshot-files
+          path: nightly-screenshot-files/
         continue-on-error: true
-        run: |
-          echo "Capturing screenshots from staging environment..."
-          npm run update:screenshots
 
-          # Check if screenshots changed
-          if git diff --quiet docs/public/screenshots/; then
-            echo "SCREENSHOTS_CHANGED=false" >> $GITHUB_ENV
-          else
-            echo "SCREENSHOTS_CHANGED=true" >> $GITHUB_ENV
-            echo "Screenshots have been updated"
-          fi
-
-      - name: Validate screenshot references and capture report
-        env:
-          DOCS_LINT_USE_CAPTURE_REPORT: 'true'
-        run: npm run lint:docs
-
-      - name: Upload capture artifacts
-        if: always()
-        uses: actions/upload-artifact@v4
+      - name: Download screenshot capture artifacts
+        uses: actions/download-artifact@v4
         with:
           name: nightly-screenshot-capture-artifacts
-          path: |
-            qa-output/capture-screenshots/
-          retention-days: 7
-
-      - name: Run QA tests
-        env:
-          VURVEY_EMAIL: ${{ secrets.VURVEY_EMAIL }}
-          VURVEY_PASSWORD: ${{ secrets.VURVEY_PASSWORD }}
-          VURVEY_URL: ${{ env.VURVEY_URL }}
-          VURVEY_WORKSPACE_ID: ${{ secrets.VURVEY_WORKSPACE_ID || '07e5edb5-e739-4a35-9f82-cc6cec7c0193' }}
-          HEADLESS: 'true'
-          QA_DEEP: 'true'
-          QA_WEB_MANAGER_DIR: 'vurvey-web-manager'
-          QA_API_DIR: 'vurvey-api'
-        run: |
-          echo "Running QA test suite..."
-          npm run test:qa -- --deep || echo "QA tests completed with some failures"
+          path: nightly-screenshot-capture/
         continue-on-error: true
 
-      - name: Run web-manager Playwright smoke tests
-        env:
-          VURVEY_EMAIL: ${{ secrets.VURVEY_EMAIL }}
-          VURVEY_PASSWORD: ${{ secrets.VURVEY_PASSWORD }}
-          VURVEY_URL: ${{ env.VURVEY_URL }}
-          QA_WEB_MANAGER_DIR: 'vurvey-web-manager'
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          echo "Running web-manager Playwright smoke tests..."
-          npm run test:qa:web-manager-playwright || echo "web-manager Playwright smoke tests completed with some failures"
-        continue-on-error: true
-
-      - name: Run mobile viewport QA
-        env:
-          VURVEY_EMAIL: ${{ secrets.VURVEY_EMAIL }}
-          VURVEY_PASSWORD: ${{ secrets.VURVEY_PASSWORD }}
-          VURVEY_URL: ${{ env.VURVEY_URL }}
-          VURVEY_WORKSPACE_ID: ${{ secrets.VURVEY_WORKSPACE_ID || '07e5edb5-e739-4a35-9f82-cc6cec7c0193' }}
-          HEADLESS: 'true'
-        run: |
-          echo "Running mobile viewport QA..."
-          npm run test:qa:mobile || echo "mobile viewport QA completed with some failures"
-        continue-on-error: true
-
-      - name: Install Playwright browsers
-        run: npx playwright install chromium --with-deps
-
-      - name: Run doc-claim Playwright tests
-        env:
-          VURVEY_EMAIL: ${{ secrets.VURVEY_EMAIL }}
-          VURVEY_PASSWORD: ${{ secrets.VURVEY_PASSWORD }}
-          VURVEY_URL: https://staging.vurvey.dev
-          VURVEY_WORKSPACE_ID: ${{ secrets.VURVEY_WORKSPACE_ID || '07e5edb5-e739-4a35-9f82-cc6cec7c0193' }}
-          FIREBASE_API_KEY: ${{ secrets.FIREBASE_API_KEY }}
-        run: npm run test:pw
-        continue-on-error: true
-
-      - name: Upload Playwright report
-        if: always()
-        uses: actions/upload-artifact@v4
+      - name: Download QA artifacts
+        uses: actions/download-artifact@v4
         with:
-          name: playwright-report
-          path: playwright/playwright-report/
-          retention-days: 7
+          name: nightly-qa-deep-artifacts
+          path: nightly-qa-deep/
+        continue-on-error: true
+
+      - name: Restore screenshot and QA output
+        run: |
+          mkdir -p docs/public bug-reports doc-fixes
+
+          QA_OUTPUT_DIR=$(find nightly-qa-deep -type d -name qa-output 2>/dev/null | head -n 1 || true)
+          if [ -n "$QA_OUTPUT_DIR" ]; then
+            rm -rf qa-output
+            cp -R "$QA_OUTPUT_DIR" .
+          else
+            mkdir -p qa-output
+          fi
+
+          QA_FAILURES_DIR=$(find nightly-qa-deep -type d -name qa-failure-screenshots 2>/dev/null | head -n 1 || true)
+          if [ -n "$QA_FAILURES_DIR" ]; then
+            rm -rf qa-failure-screenshots
+            cp -R "$QA_FAILURES_DIR" .
+          else
+            mkdir -p qa-failure-screenshots
+          fi
+
+          SCREENSHOT_DIR=$(find nightly-screenshot-files -type d -name screenshots 2>/dev/null | head -n 1 || true)
+          if [ -n "$SCREENSHOT_DIR" ]; then
+            rm -rf docs/public/screenshots
+            cp -R "$SCREENSHOT_DIR" docs/public/
+          fi
+
+          CAPTURE_DIR=$(find nightly-screenshot-capture -type d -name capture-screenshots 2>/dev/null | head -n 1 || true)
+          if [ -n "$CAPTURE_DIR" ]; then
+            rm -rf qa-output/capture-screenshots
+            mkdir -p qa-output
+            cp -R "$CAPTURE_DIR" qa-output/
+          fi
 
       - name: Analyze QA failures
         id: analyze_qa
@@ -167,7 +385,6 @@ jobs:
           echo "Analyzing QA test failures..."
           node scripts/qa-failure-analyzer.js || echo "QA failure analysis completed with errors"
 
-          # Check if failures were found
           if [ -f "qa-output/qa-analysis-input.json" ]; then
             TOTAL_FAILURES=$(cat qa-output/qa-analysis-input.json | jq '.total_failures // 0')
             echo "QA_TOTAL_FAILURES=$TOTAL_FAILURES" >> $GITHUB_ENV
@@ -200,10 +417,8 @@ jobs:
         run: |
           echo "Running Claude Code analysis..."
 
-          # Build enhanced prompt with QA context
           PROMPT_CONTENT=$(cat scripts/claude-doc-updater-prompt.md)
 
-          # Append QA failure context if available
           if [ "$QA_TOTAL_FAILURES" -gt 0 ] && [ -f "qa-output/qa-analysis-input.json" ]; then
             QA_CONTEXT=$(cat qa-output/qa-analysis-input.json)
             PROMPT_CONTENT="$PROMPT_CONTENT
@@ -252,19 +467,19 @@ jobs:
           echo "QA remediation complete"
 
       - name: Validate documentation accuracy
+        timeout-minutes: 20
+        continue-on-error: true
         env:
           VURVEY_EMAIL: ${{ secrets.VURVEY_EMAIL }}
           VURVEY_PASSWORD: ${{ secrets.VURVEY_PASSWORD }}
           VURVEY_URL: ${{ env.VURVEY_URL }}
           VURVEY_WORKSPACE_ID: ${{ secrets.VURVEY_WORKSPACE_ID || '07e5edb5-e739-4a35-9f82-cc6cec7c0193' }}
           HEADLESS: 'true'
-        continue-on-error: true
         run: node scripts/qa-doc-validator.js
 
       - name: Check for bug reports and doc fixes
         id: check_bugs
         run: |
-          # Check bug reports - collect valid JSON files into an array
           if [ -d "bug-reports" ] && ls bug-reports/*.json >/dev/null 2>&1; then
             BUG_REPORTS=$(jq -s '.' bug-reports/*.json 2>/dev/null || echo '[]')
             BUG_COUNT=$(echo "$BUG_REPORTS" | jq 'length')
@@ -286,7 +501,6 @@ jobs:
             echo "No bug reports found"
           fi
 
-          # Check doc fixes - collect valid JSON files into an array
           if [ -d "doc-fixes" ] && ls doc-fixes/*.json >/dev/null 2>&1; then
             DOC_FIXES=$(jq -s '.' doc-fixes/*.json 2>/dev/null || echo '[]')
             FIX_COUNT=$(echo "$DOC_FIXES" | jq 'length')
@@ -309,7 +523,13 @@ jobs:
       - name: Check for documentation changes
         id: check_changes
         run: |
-          git add -A
+          git add -- docs/ doc-fixes/
+          for file in DOCUMENTATION_AUDIT_SUMMARY.md REMEDIATION_SUMMARY.md DOC_FIX_SUMMARY.md; do
+            if [ -f "$file" ]; then
+              git add -- "$file"
+            fi
+          done
+
           if git diff --staged --quiet; then
             echo "changes=false" >> $GITHUB_OUTPUT
             echo "No documentation changes detected"
@@ -360,35 +580,49 @@ jobs:
             documentation
             automated
 
-      - name: Collect QA artifacts
-        if: always()
-        run: |
-          mkdir -p /tmp/qa-artifacts
-          cp -r qa-output /tmp/qa-artifacts/ 2>/dev/null || echo "No qa-output"
-          cp screenshot-validation-report.md /tmp/qa-artifacts/ 2>/dev/null || echo "No screenshot-validation-report.md"
-          cp DOCUMENTATION_AUDIT_SUMMARY.md /tmp/qa-artifacts/ 2>/dev/null || echo "No DOCUMENTATION_AUDIT_SUMMARY.md"
-          cp -r qa-failure-screenshots /tmp/qa-artifacts/ 2>/dev/null || echo "No qa-failure-screenshots"
-          cp -r bug-reports /tmp/qa-artifacts/ 2>/dev/null || echo "No bug-reports"
-          cp -r doc-fixes /tmp/qa-artifacts/ 2>/dev/null || echo "No doc-fixes"
-          cp /tmp/claude-log.txt /tmp/qa-artifacts/ 2>/dev/null || echo "No claude-log.txt"
-          cp /tmp/claude-remediation-log.txt /tmp/qa-artifacts/ 2>/dev/null || echo "No remediation log"
-          cp REMEDIATION_SUMMARY.md /tmp/qa-artifacts/ 2>/dev/null || echo "No REMEDIATION_SUMMARY.md"
-          cp qa-output/qa-analysis-input.json /tmp/qa-artifacts/ 2>/dev/null || echo "No qa-analysis-input.json"
-          cp qa-output/qa-failure-analysis.md /tmp/qa-artifacts/ 2>/dev/null || echo "No qa-failure-analysis.md"
-          cp qa-output/test-fixes-needed.md /tmp/qa-artifacts/ 2>/dev/null || echo "No test-fixes-needed.md"
-          cp -r vurvey-web-manager/test-results /tmp/qa-artifacts/ 2>/dev/null || echo "No web-manager test-results"
-          cp -r vurvey-web-manager/playwright-report /tmp/qa-artifacts/ 2>/dev/null || echo "No web-manager playwright-report"
-          ls -laR /tmp/qa-artifacts/
-
-      - name: Upload analysis artifacts
+      - name: Upload nightly analysis artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: documentation-analysis
-          path: /tmp/qa-artifacts/
+          name: nightly-analysis-artifacts
+          path: |
+            qa-output/
+            qa-failure-screenshots/
+            bug-reports/
+            doc-fixes/
+            DOCUMENTATION_AUDIT_SUMMARY.md
+            REMEDIATION_SUMMARY.md
+            screenshot-validation-report.md
+            /tmp/claude-log.txt
+            /tmp/claude-remediation-log.txt
           retention-days: 7
+          if-no-files-found: ignore
 
-  # Dispatch bug reports to vurvey-web-manager
+  collect-analysis-artifacts:
+    needs:
+      - capture-screenshots
+      - qa-deep
+      - qa-web-manager-smoke
+      - qa-mobile-viewport
+      - qa-doc-claims
+      - sync-documentation
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all nightly artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: collected-artifacts/
+
+      - name: Upload combined analysis artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation-analysis
+          path: collected-artifacts/
+          retention-days: 7
+          if-no-files-found: ignore
+
   dispatch-frontend-bugs:
     needs: sync-documentation
     if: needs.sync-documentation.outputs.has_bug_reports == 'true' && inputs.skip_bug_dispatch != true
@@ -416,8 +650,6 @@ jobs:
 
       - name: Dispatch to vurvey-web-manager
         if: steps.filter_bugs.outputs.has_frontend_bugs == 'true'
-        env:
-          FRONTEND_BUGS: ${{ steps.filter_bugs.outputs.frontend_bugs }}
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.VURVEY_REPO_TOKEN }}
@@ -426,7 +658,6 @@ jobs:
           client-payload: >-
             {"source":"vurvey-docs-site","workflow_run_id":"${{ github.run_id }}","bug_reports":${{ steps.filter_bugs.outputs.frontend_bugs }}}
 
-  # Dispatch bug reports to vurvey-api
   dispatch-backend-bugs:
     needs: sync-documentation
     if: needs.sync-documentation.outputs.has_bug_reports == 'true' && inputs.skip_bug_dispatch != true
@@ -463,7 +694,16 @@ jobs:
             {"source":"vurvey-docs-site","workflow_run_id":"${{ github.run_id }}","bug_reports":${{ steps.filter_bugs.outputs.backend_bugs }}}
 
   notify-on-failure:
-    needs: [sync-documentation, dispatch-frontend-bugs, dispatch-backend-bugs]
+    needs:
+      - capture-screenshots
+      - qa-deep
+      - qa-web-manager-smoke
+      - qa-mobile-viewport
+      - qa-doc-claims
+      - sync-documentation
+      - collect-analysis-artifacts
+      - dispatch-frontend-bugs
+      - dispatch-backend-bugs
     if: failure()
     runs-on: ubuntu-latest
     steps:
@@ -472,7 +712,13 @@ jobs:
           echo "::error::Nightly documentation sync workflow failed."
           echo ""
           echo "Job statuses:"
+          echo "  capture-screenshots:    ${{ needs.capture-screenshots.result }}"
+          echo "  qa-deep:                ${{ needs.qa-deep.result }}"
+          echo "  qa-web-manager-smoke:   ${{ needs.qa-web-manager-smoke.result }}"
+          echo "  qa-mobile-viewport:     ${{ needs.qa-mobile-viewport.result }}"
+          echo "  qa-doc-claims:          ${{ needs.qa-doc-claims.result }}"
           echo "  sync-documentation:     ${{ needs.sync-documentation.result }}"
+          echo "  collect-artifacts:      ${{ needs.collect-analysis-artifacts.result }}"
           echo "  dispatch-frontend-bugs: ${{ needs.dispatch-frontend-bugs.result }}"
           echo "  dispatch-backend-bugs:  ${{ needs.dispatch-backend-bugs.result }}"
           echo ""

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ qa-failure-report.md
 screenshot-validation-report.md
 qa-report.json
 qa-output/
+qa-artifacts-download/
+nightly-*/
+collected-artifacts/
 
 # Screenshot capture retries/errors (noise; keep docs screenshots clean)
 docs/public/screenshots/retry-*.png


### PR DESCRIPTION
## Summary
- Parallelizes the nightly docs workflow so screenshot capture, deep QA, smoke/mobile QA, and doc-claim Playwright runs execute as separate jobs.
- Lets the PR-producing sync job continue after screenshot and deep-QA artifacts are ready, instead of waiting on the full doc-claim suite.
- Restricts automated PR staging to documentation outputs and ignores downloaded artifact folders so analysis artifacts do not get committed.

## Root Cause
`Nightly Documentation Sync` runs the full doc-claim Playwright suite inside one 90 minute `sync-documentation` job. Recent scheduled runs cancel during `Run doc-claim Playwright tests` before analysis and PR creation can run.

Latest example: run `24703434411` started `Run doc-claim Playwright tests` at `2026-04-21T04:59:28Z` and was canceled at `2026-04-21T05:36:09Z`, so `Analyze QA failures`, `Run documentation analysis and updates`, and `Create Pull Request` were skipped.

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly-docs-sync.yml")'`
- `npm run test:docs`
- `npx playwright test --config=playwright/playwright.config.ts --list --shard=1/20`
- `npm run docs:build`
